### PR TITLE
test: 공지사항 단위테스트 코드 구현

### DIFF
--- a/src/test/java/com/ahi/timecapsule/TestSecurityConfig.java
+++ b/src/test/java/com/ahi/timecapsule/TestSecurityConfig.java
@@ -1,0 +1,34 @@
+package com.ahi.timecapsule;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+@EnableWebSecurity
+public class TestSecurityConfig {
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http.csrf(csrf -> csrf.disable())
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers(HttpMethod.GET, "/notices", "/notices/*")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.POST, "/notices/*")
+                    .hasRole("ADMIN")
+                    .requestMatchers(HttpMethod.DELETE, "/notices/**")
+                    .hasRole("ADMIN")
+                    .requestMatchers("/notices/form", "/notices/*/edit")
+                    .hasRole("ADMIN")
+                    .requestMatchers("/static/**", "/css/**", "/js/**", "/images/**")
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated());
+
+    return http.build();
+  }
+}

--- a/src/test/java/com/ahi/timecapsule/controller/NoticeControllerTest.java
+++ b/src/test/java/com/ahi/timecapsule/controller/NoticeControllerTest.java
@@ -1,0 +1,232 @@
+package com.ahi.timecapsule.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.ahi.timecapsule.TestSecurityConfig;
+import com.ahi.timecapsule.config.JwtTokenProvider;
+import com.ahi.timecapsule.config.UserDetailService;
+import com.ahi.timecapsule.dto.notice.request.NoticeCreateDTO;
+import com.ahi.timecapsule.dto.notice.request.NoticeUpdateDTO;
+import com.ahi.timecapsule.dto.notice.response.NoticeDetailDTO;
+import com.ahi.timecapsule.dto.notice.response.NoticeListDTO;
+import com.ahi.timecapsule.service.NoticeService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(value = NoticeController.class)
+@Import(TestSecurityConfig.class)
+public class NoticeControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private NoticeService noticeService;
+
+  @MockBean private JwtTokenProvider jwtTokenProvider;
+
+  @MockBean
+  @SuppressWarnings("unused")
+  private UserDetailService userDetailService;
+
+  private final LocalDateTime fixedTime = LocalDateTime.of(2024, 9, 4, 0, 0);
+
+  private NoticeDetailDTO createNoticeDetailDTO(Integer id, String title, String content) {
+    return NoticeDetailDTO.builder()
+        .id(id)
+        .title(title)
+        .content(content)
+        .createdAt(fixedTime)
+        .updatedAt(fixedTime)
+        .userId("testUser")
+        .userNickname("admin")
+        .build();
+  }
+
+  @Test
+  @DisplayName("전체 공지사항 목록 조회 테스트")
+  public void testGetNoticeList() throws Exception {
+    List<NoticeListDTO> notices =
+        List.of(
+            new NoticeListDTO(1, "Test Title 1", fixedTime, fixedTime, "admin"),
+            new NoticeListDTO(2, "Test Title 2", fixedTime, fixedTime, "admin"));
+
+    Page<NoticeListDTO> noticePage = new PageImpl<>(notices, PageRequest.of(0, 10), 2);
+
+    when(noticeService.getAllNotices(any(Pageable.class))).thenReturn(noticePage);
+
+    mockMvc
+        .perform(get("/notices").param("page", "0").param("size", "10"))
+        .andExpect(status().isOk())
+        .andExpect(model().attributeExists("notices"))
+        .andExpect(model().attribute("notices", noticePage))
+        .andExpect(model().attributeDoesNotExist("searchTerm"))
+        .andExpect(view().name("notice/list"));
+
+    verify(noticeService).getAllNotices(any(Pageable.class));
+  }
+
+  @Test
+  @DisplayName("공지사항 검색 테스트")
+  public void testGetNoticeListWithSearchTerm() throws Exception {
+    List<NoticeListDTO> notices =
+        List.of(new NoticeListDTO(1, "Test Title 1", fixedTime, fixedTime, "admin"));
+
+    Page<NoticeListDTO> noticePage = new PageImpl<>(notices, PageRequest.of(0, 10), 1);
+
+    when(noticeService.searchNotices(eq("Test"), eq("Test"), any(Pageable.class)))
+        .thenReturn(noticePage);
+
+    mockMvc
+        .perform(get("/notices").param("page", "0").param("size", "10").param("searchTerm", "Test"))
+        .andExpect(status().isOk())
+        .andExpect(model().attributeExists("notices"))
+        .andExpect(model().attribute("notices", noticePage))
+        .andExpect(model().attributeExists("searchTerm"))
+        .andExpect(model().attribute("searchTerm", "Test"))
+        .andExpect(view().name("notice/list"));
+
+    verify(noticeService).searchNotices(eq("Test"), eq("Test"), any(Pageable.class));
+  }
+
+  @Test
+  @DisplayName("특정 공지사항 상세 조회 테스트")
+  public void testFindNoticeDetail() throws Exception {
+    Integer noticeId = 1;
+    NoticeDetailDTO noticeDetail = createNoticeDetailDTO(noticeId, "Test Title", "Test Content");
+    when(noticeService.getDetailNotice(noticeId)).thenReturn(noticeDetail);
+
+    mockMvc
+        .perform(get("/notices/{id}", noticeId))
+        .andExpect(status().isOk())
+        .andExpect(model().attributeExists("notice"))
+        .andExpect(model().attribute("notice", noticeDetail))
+        .andExpect(view().name("notice/detail"));
+
+    verify(noticeService).getDetailNotice(noticeId);
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  @DisplayName("공지사항 생성 폼 조회 테스트")
+  public void testGetCreateNoticeForm() throws Exception {
+    mockMvc
+        .perform(get("/notices/form"))
+        .andExpect(status().isOk())
+        .andExpect(model().attributeExists("noticeForm"))
+        .andExpect(view().name("notice/form"));
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  @DisplayName("공지사항 생성 테스트")
+  public void testCreateNotice() throws Exception {
+    NoticeDetailDTO createdNotice = createNoticeDetailDTO(1, "Test Title", "Test Content");
+
+    when(jwtTokenProvider.getUsernameFromJwtToken(anyString())).thenReturn("testUser");
+    when(noticeService.createNotice(any(NoticeCreateDTO.class), anyString()))
+        .thenReturn(createdNotice);
+
+    mockMvc
+        .perform(
+            post("/notices")
+                .header("Authorization", "Bearer fake-token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .param("title", "Test Title")
+                .param("content", "Test Content"))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl("/notices/" + createdNotice.getId()));
+
+    verify(noticeService).createNotice(any(NoticeCreateDTO.class), anyString());
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  @DisplayName("공지사항 생성 유효성 검사 실패 테스트")
+  public void testCreateNotice_ValidationFailure() throws Exception {
+    mockMvc
+        .perform(
+            post("/notices")
+                .header("Authorization", "Bearer fake-token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .param("title", "")
+                .param("content", "Test Content"))
+        .andExpect(status().isOk())
+        .andExpect(model().attributeHasFieldErrors("noticeForm", "title"))
+        .andExpect(view().name("notice/form"));
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  @DisplayName("공지사항 수정 폼 조회 테스트")
+  public void testGetUpdateNoticeForm() throws Exception {
+    Integer noticeId = 1;
+    NoticeDetailDTO noticeDetail = createNoticeDetailDTO(noticeId, "Test Title", "Test Content");
+
+    when(noticeService.getDetailNotice(noticeId)).thenReturn(noticeDetail);
+
+    mockMvc
+        .perform(get("/notices/{id}/edit", noticeId))
+        .andExpect(status().isOk())
+        .andExpect(model().attributeExists("noticeForm"))
+        .andExpect(model().attribute("noticeForm", noticeDetail))
+        .andExpect(view().name("notice/edit"));
+
+    verify(noticeService).getDetailNotice(noticeId);
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  @DisplayName("공지사항 수정 테스트")
+  public void testUpdateNotice() throws Exception {
+    Integer noticeId = 1;
+    NoticeUpdateDTO updateDTO =
+        new NoticeUpdateDTO(noticeId, "Updated Test Title", "Updated Test Content");
+
+    mockMvc
+        .perform(
+            post("/notices/{id}", noticeId)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .param("title", "Updated Test Title")
+                .param("content", "Updated Test Content"))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl("/notices/1"));
+
+    verify(noticeService).updateNotice(eq(noticeId), any(NoticeUpdateDTO.class));
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  @DisplayName("공지사항 삭제 테스트")
+  public void testDeleteNotice() throws Exception {
+    Integer noticeId = 1;
+
+    mockMvc.perform(delete("/notices/{id}", noticeId)).andExpect(status().isOk());
+
+    verify(noticeService).deleteNotice(noticeId);
+  }
+
+  @Test
+  @WithMockUser(roles = "USER")
+  @DisplayName("비관리자 공지사항 삭제 실패 테스트")
+  public void testNonAdminDeleteNotice() throws Exception {
+    Integer noticeId = 1;
+
+    mockMvc.perform(delete("/notices/{id}", noticeId)).andExpect(status().isForbidden());
+  }
+}

--- a/src/test/java/com/ahi/timecapsule/repository/NoticeRepositoryTest.java
+++ b/src/test/java/com/ahi/timecapsule/repository/NoticeRepositoryTest.java
@@ -1,0 +1,91 @@
+package com.ahi.timecapsule.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ahi.timecapsule.entity.Notice;
+import com.ahi.timecapsule.entity.User;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.TestPropertySource;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(locations = "classpath:application.yml")
+public class NoticeRepositoryTest {
+
+  @Autowired private UserRepository userRepository;
+
+  @Autowired private NoticeRepository noticeRepository;
+
+  private User user;
+
+  private final LocalDateTime fixedTime = LocalDateTime.of(2024, 9, 3, 0, 0);
+
+  @BeforeEach
+  public void setUp() {
+    noticeRepository.deleteAll();
+    userRepository.deleteAll();
+
+    user = createUser();
+    userRepository.save(user);
+  }
+
+  private User createUser() {
+    return User.builder()
+        .userId("testUser")
+        .password("password")
+        .email("test@example.com")
+        .nickname("tester")
+        .role(1)
+        .build();
+  }
+
+  private Notice createNotice(String title, String content, LocalDateTime dateTime) {
+    return Notice.builder()
+        .title(title)
+        .content(content)
+        .createdAt(dateTime)
+        .updatedAt(dateTime)
+        .user(user)
+        .build();
+  }
+
+  @Test
+  @DisplayName("전체 공지사항 조회 테스트")
+  public void testFindAllByOrderByCreatedAtDesc() {
+    Notice notice1 = createNotice("test1", "content1", fixedTime);
+    Notice notice2 = createNotice("test2", "content2", fixedTime.plusSeconds(1));
+
+    noticeRepository.saveAll(List.of(notice1, notice2));
+
+    Pageable pageable = PageRequest.of(0, 10);
+    Page<Notice> result = noticeRepository.findAllByOrderByCreatedAtDesc(pageable);
+
+    assertThat(result).isNotNull().hasSize(2).containsExactly(notice2, notice1);
+  }
+
+  @Test
+  @DisplayName("제목, 내용 검색 공지사항 조회 테스트")
+  public void testFindByTitleOrContentOrderByCreatedAtDesc() {
+    Notice notice1 = createNotice("test", "content", fixedTime);
+    Notice notice2 = createNotice("test1", "content1", fixedTime.plusHours(1));
+    Notice notice3 = createNotice("java", "javaContent", fixedTime.plusDays(2));
+
+    noticeRepository.saveAll(List.of(notice1, notice2, notice3));
+
+    Pageable pageable = PageRequest.of(0, 10);
+    Page<Notice> result =
+        noticeRepository.findByTitleOrContentOrderByCreatedAtDesc("test", "content", pageable);
+
+    assertThat(result).isNotNull().hasSize(3).containsExactly(notice3, notice2, notice1);
+  }
+}

--- a/src/test/java/com/ahi/timecapsule/service/NoticeServiceTest.java
+++ b/src/test/java/com/ahi/timecapsule/service/NoticeServiceTest.java
@@ -1,0 +1,197 @@
+package com.ahi.timecapsule.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ahi.timecapsule.dto.notice.request.NoticeCreateDTO;
+import com.ahi.timecapsule.dto.notice.request.NoticeUpdateDTO;
+import com.ahi.timecapsule.dto.notice.response.NoticeDetailDTO;
+import com.ahi.timecapsule.entity.Notice;
+import com.ahi.timecapsule.entity.User;
+import com.ahi.timecapsule.exception.NoticeNotFoundException;
+import com.ahi.timecapsule.exception.UserNotFoundException;
+import com.ahi.timecapsule.repository.NoticeRepository;
+import com.ahi.timecapsule.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class NoticeServiceTest {
+
+  @Mock private UserRepository userRepository;
+
+  @Mock private NoticeRepository noticeRepository;
+
+  @InjectMocks private NoticeService noticeService;
+
+  private final LocalDateTime fixedTime = LocalDateTime.of(2024, 9, 4, 1, 0);
+
+  private User createUser() {
+    return User.builder().userId("testUser").nickname("Test User").build();
+  }
+
+  @Test
+  @DisplayName("공지사항 생성 테스트")
+  public void testCreateNotice() {
+    User user = createUser();
+    String userNickname = "Test User";
+    NoticeCreateDTO createDTO = new NoticeCreateDTO("Test Title", "Test Content");
+
+    Notice savedNotice =
+        Notice.builder()
+            .id(1)
+            .title("Test Title")
+            .content("Test Content")
+            .createdAt(fixedTime)
+            .updatedAt(fixedTime)
+            .user(user)
+            .build();
+
+    when(userRepository.findByNickname(userNickname)).thenReturn(Optional.of(user));
+    when(noticeRepository.save(any(Notice.class))).thenReturn(savedNotice);
+
+    NoticeDetailDTO result = noticeService.createNotice(createDTO, "Test User");
+
+    assertThat(result).isNotNull();
+    assertThat(result.getTitle()).isEqualTo("Test Title");
+    assertThat(result.getContent()).isEqualTo("Test Content");
+    assertThat(result.getUserNickname()).isEqualTo(userNickname);
+    assertThat(result.getCreatedAt()).isEqualTo(fixedTime);
+    assertThat(result.getUpdatedAt()).isEqualTo(fixedTime);
+
+    verify(userRepository).findByNickname(userNickname);
+    verify(noticeRepository).save(any(Notice.class));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 닉네임 공지사항 생성 예외 발생 테스트")
+  public void testCreateNoticeWithException() {
+    String nonExistentUserNickname = "Existent User";
+    NoticeCreateDTO createDTO = new NoticeCreateDTO("Test Title", "Test Content");
+
+    when(userRepository.findByNickname(nonExistentUserNickname)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> noticeService.createNotice(createDTO, nonExistentUserNickname))
+        .isInstanceOf(UserNotFoundException.class)
+        .hasMessage("사용자를 찾을 수 없습니다." + nonExistentUserNickname);
+
+    verify(userRepository).findByNickname(nonExistentUserNickname);
+  }
+
+  @Test
+  @DisplayName("공지사항 상세조회 테스트")
+  public void testGetDetailNotice() {
+    Integer noticeId = 1;
+    User user = createUser();
+
+    Notice notice =
+        Notice.builder()
+            .id(noticeId)
+            .title("Test Title")
+            .content("Test Content")
+            .createdAt(fixedTime)
+            .updatedAt(fixedTime)
+            .user(user)
+            .build();
+
+    when(noticeRepository.findById(noticeId)).thenReturn(Optional.of(notice));
+
+    NoticeDetailDTO result = noticeService.getDetailNotice(noticeId);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo(noticeId);
+    assertThat(result.getTitle()).isEqualTo("Test Title");
+    assertThat(result.getContent()).isEqualTo("Test Content");
+    assertThat(result.getCreatedAt()).isEqualTo(fixedTime);
+    assertThat(result.getUpdatedAt()).isEqualTo(fixedTime);
+
+    verify(noticeRepository).findById(noticeId);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 공지사항 조회 예외 발생 테스트")
+  public void testGetDetailNoticeNotFound() {
+    Integer nonExistentNoticeId = 1;
+
+    assertThatThrownBy(() -> noticeService.getDetailNotice(nonExistentNoticeId))
+        .isInstanceOf(NoticeNotFoundException.class)
+        .hasMessage("해당 공지사항은 존재하지 않습니다.");
+
+    verify(noticeRepository).findById(nonExistentNoticeId);
+  }
+
+  @Test
+  @DisplayName("공지사항 수정 테스트")
+  public void testUpdateNotice() {
+    Integer noticeId = 1;
+    User user = createUser();
+    NoticeUpdateDTO updateDTO = new NoticeUpdateDTO(noticeId, "Updated Title", "Updated Content");
+
+    Notice existingNotice =
+        Notice.builder()
+            .id(noticeId)
+            .title("Old Title")
+            .content("Old Content")
+            .createdAt(fixedTime)
+            .updatedAt(fixedTime)
+            .user(user)
+            .build();
+    Notice updatedNotice =
+        Notice.builder()
+            .id(noticeId)
+            .title("Updated Title")
+            .content("Updated Content")
+            .createdAt(fixedTime)
+            .updatedAt(fixedTime.plusDays(1))
+            .user(user)
+            .build();
+
+    when(noticeRepository.findById(noticeId)).thenReturn(Optional.of(existingNotice));
+    when(noticeRepository.save(any(Notice.class))).thenReturn(updatedNotice);
+
+    NoticeDetailDTO result = noticeService.updateNotice(noticeId, updateDTO);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo(noticeId);
+    assertThat(result.getTitle()).isEqualTo("Updated Title");
+    assertThat(result.getContent()).isEqualTo("Updated Content");
+    assertThat(result.getCreatedAt()).isEqualTo(fixedTime);
+    assertThat(result.getUpdatedAt()).isEqualTo(fixedTime.plusDays(1));
+
+    verify(noticeRepository).findById(noticeId);
+    verify(noticeRepository).save(any(Notice.class));
+  }
+
+  @Test
+  @DisplayName("공지사항 삭제 테스트")
+  public void testDeleteNotice() {
+    Integer noticeId = 1;
+    User user = createUser();
+
+    Notice notice =
+        Notice.builder()
+            .id(noticeId)
+            .title("Test Title")
+            .content("Test Content")
+            .createdAt(fixedTime)
+            .updatedAt(fixedTime)
+            .user(user)
+            .build();
+
+    when(noticeRepository.findById(noticeId)).thenReturn(Optional.of(notice));
+
+    noticeService.deleteNotice(noticeId);
+
+    verify(noticeRepository).findById(noticeId);
+    verify(noticeRepository).delete(notice);
+  }
+}


### PR DESCRIPTION
## :white_check_mark:  개요
공지사항 단위테스트 코드 구현

## 상세 내용
NoticeRepositoryTest 코드 2개 구현
NoticeServiceTest 코드 6개 구현
NoticeControllerTest 코드 10개 구현
NoticeControllerTest를 위한 TestSecurityConfig 코드 구현
(SecurityConfig 원본 파일은 복잡한 코드들이 많아서 공지사항에서 필요한 코드들만 작성해서 테스트 돌렸습니다)

## 이슈
Issue Number: (#19)
